### PR TITLE
Add add_specs to api

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -96,7 +96,7 @@ class Api(object):
             tags=None, prefix='', ordered=False,
             default_mediatype='application/json', decorators=None,
             catch_all_404s=False, serve_challenge_on_401=False, format_checker=None,
-            **kwargs):
+            add_specs=True, **kwargs):
         self.version = version
         self.title = title or 'API'
         self.description = description
@@ -148,7 +148,7 @@ class Api(object):
 
         if app is not None:
             self.app = app
-            self.init_app(app)
+            self.init_app(app, add_specs=add_specs)
         # super(Api, self).__init__(app, **kwargs)
 
     def init_app(self, app, **kwargs):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,6 +95,11 @@ class APITest(object):
         resp = client.get('/swagger.json')
         assert resp.status_code == 404
 
+    def test_specs_endpoint_not_found_if_not_enabled(self, app, client):
+        api = restplus.Api(app, add_specs=False)
+        resp = client.get('/swagger.json')
+        assert resp.status_code == 404
+
     def test_default_endpoint(self, app):
         api = restplus.Api(app)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,11 +95,6 @@ class APITest(object):
         resp = client.get('/swagger.json')
         assert resp.status_code == 404
 
-    def test_specs_endpoint_not_found_if_not_enabled(self, app, client):
-        api = restplus.Api(app, add_specs=False)
-        resp = client.get('/swagger.json')
-        assert resp.status_code == 404
-
     def test_default_endpoint(self, app):
         api = restplus.Api(app)
 


### PR DESCRIPTION
Adds an option to Api to give the option not to enable spec endpoint if not lazy loading an app.

References https://github.com/noirbizarre/flask-restplus/issues/464